### PR TITLE
feat: don't print on noop

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,9 @@ task(NAME, DESC, async function (args, hre) {
     }
   });
 
-  console.log(`Prepended SPDX License Identifier "${ license }" to ${ count } sources.`);
+  if (count > 0) {
+    console.log(`Prepended SPDX License Identifier "${ license }" to ${ count } sources.`);
+  }
 });
 
 task(TASK_COMPILE, async function (args, hre, runSuper) {


### PR DESCRIPTION
99% of the time, there aren't any new files to have licenses inserted into yet this plugin prints out `Prepended SPDX License Identifier "MIT" to 0 sources.` possibly multiple times.

This doesn't seem particularly valuable and it would be better if the plugin only printed if it has found a file without a proper SPDX license identifier.