### PR TITLE
replace deprecated hook

### DIFF
--- a/src/hooks/solidity.ts
+++ b/src/hooks/solidity.ts
@@ -1,20 +1,14 @@
 import {
+  filterSourcePaths,
   hasMatchingLicense,
   prependLicenseToFileContent,
   readLicenseFromPackageJson,
 } from '../lib/license_identifier.js';
-import { writeUtf8File } from '@nomicfoundation/hardhat-utils/fs';
+import { readUtf8File, writeUtf8File } from '@nomicfoundation/hardhat-utils/fs';
 import type { SolidityHooks } from 'hardhat/types/hooks';
 
 export default async (): Promise<Partial<SolidityHooks>> => ({
-  preprocessProjectFileBeforeBuilding: async (
-    context,
-    sourceName,
-    fsPath,
-    fileContent,
-    solcVersion,
-    next,
-  ) => {
+  build: async (context, rootFilePaths, options, next) => {
     const config = context.config.licenseIdentifier;
 
     if (config.runOnCompile) {
@@ -23,12 +17,25 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
         (await readLicenseFromPackageJson(context.config.paths.root));
       const overwrite = config.overwrite;
 
-      if (!hasMatchingLicense(fileContent, license, overwrite)) {
-        fileContent = prependLicenseToFileContent(fileContent, license);
-        await writeUtf8File(fsPath, fileContent);
-      }
+      const sourcePaths = filterSourcePaths(
+        config,
+        await context.solidity.getRootFilePaths(),
+      );
+
+      await Promise.all(
+        sourcePaths.map(async (sourcePath) => {
+          const content = await readUtf8File(sourcePath);
+
+          if (!hasMatchingLicense(content, license, overwrite)) {
+            await writeUtf8File(
+              sourcePath,
+              prependLicenseToFileContent(content, license),
+            );
+          }
+        }),
+      );
     }
 
-    return await next(context, sourceName, fsPath, fileContent, solcVersion);
+    return next(context, rootFilePaths, options);
   },
 });

--- a/src/hooks/solidity.ts
+++ b/src/hooks/solidity.ts
@@ -17,10 +17,7 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
         (await readLicenseFromPackageJson(context.config.paths.root));
       const overwrite = config.overwrite;
 
-      const sourcePaths = filterSourcePaths(
-        config,
-        await context.solidity.getRootFilePaths(),
-      );
+      const sourcePaths = filterSourcePaths(config, rootFilePaths);
 
       await Promise.all(
         sourcePaths.map(async (sourcePath) => {

--- a/src/hooks/solidity.ts
+++ b/src/hooks/solidity.ts
@@ -36,6 +36,6 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
       );
     }
 
-    return next(context, rootFilePaths, options);
+    return await next(context, rootFilePaths, options);
   },
 });


### PR DESCRIPTION
The `preprocessProjectFileBeforeBuilding` hook is deprecated.  There is no direct alternative, so we're now using the top-level `build` hook.  I believe this matches the old Hardhat 2 behavior.

This appears to also fix an issue where source path filters were not being respected.